### PR TITLE
Revert "fixing suggested citiation author info"

### DIFF
--- a/_includes/suggestedcitiation.html
+++ b/_includes/suggestedcitiation.html
@@ -2,7 +2,8 @@
 <h2 class="suggested-citation-header">{{ site.data.snippets.suggested-citation }}</h2>
     <div class="suggested-citation-text">
       <p class="suggested-citation-text">
-        {% assign author = page.authors | default: site.author %}
+        {% assign author = page.author | default: page.authors[0] | default: site.author %}
+        {% assign author = site.data.authors[author] | default: author %}
         {{ author.name }},
         {{ site.data.snippets.title-open-quote }}{{ page.title | strip }}{{ site.data.snippets.title-close-quote }}
         {% if page.translator %}


### PR DESCRIPTION
Reverts adamdjbrett/doctrineofdiscovery.org#22
 posts only showing fall back site.author and not page.author @vidhyav656 